### PR TITLE
removed query cancel from ParseObservable.get()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@ android {
 
 dependencies {
     compile 'io.reactivex:rxjava:1.0.7'
-    compile 'com.infstory:parse:1.8.1'
+    //compile 'com.infstory:parse:1.8.1'
     //compile 'com.facebook.android:facebook-android-sdk:3.20.0'
-    compile 'com.parse.bolts:bolts-android:1.1.4'
+    //compile 'com.parse.bolts:bolts-android:1.1.4'
     //testCompile "org.mockito:mockito-core:1.+"
 }
 

--- a/src/main/java/rx/parse/ParseObservable.java
+++ b/src/main/java/rx/parse/ParseObservable.java
@@ -153,12 +153,16 @@ public class ParseObservable<T extends ParseObject> {
 
     public static <R extends ParseObject> Observable<R> get(Class<R> clazz, String objectId) {
         ParseQuery<R> query = ParseQuery.getQuery(clazz);
-        return toObservable(query.getInBackground(objectId))
-            .doOnUnsubscribe(() -> Observable.just(query)
+        return toObservable(query.getInBackground(objectId));
+		// If this part of the chain is removed then the query starts working
+		// else it only responds with ParseException, code 101, OBJECT_NOT_FOUND
+		// Why is this part of the code neccesary? If it is neccesary then please guide me
+		// as to how to get this working.
+            /*.doOnUnsubscribe(() -> Observable.just(query)
                 .doOnNext(q -> q.cancel())
                 .timeout(1, TimeUnit.SECONDS)
                 .subscribeOn(Schedulers.io())
-                .subscribe(o -> {}, e -> {}));
+                .subscribe(o -> {}, e -> {})); */
     }
 
     @Deprecated


### PR DESCRIPTION
If this part of the chain is removed then the query starts working else it only responds with ParseException, code 101, OBJECT_NOT_FOUND.

Why is this part of the code necessary? If it is necessary then please guide me as to how to get this working.
