### PR TITLE
Fix pin behaviour

### DIFF
--- a/rxparse2/src/main/java/rx/parse2/ParseObservable.java
+++ b/rxparse2/src/main/java/rx/parse2/ParseObservable.java
@@ -65,12 +65,12 @@ public class ParseObservable {
     }
 
     public static <R extends ParseObject> Observable<R> pin(R object) {
-        return TaskObservable.defer(() -> object.pinInBackground())
+        return TaskObservable.defer(() -> object.pinInBackground().continueWith(v -> object))
                 .map(v -> object);
     }
 
     public static <R extends ParseObject> Observable<R> pin(List<R> objects) {
-        return TaskObservable.defer(() -> ParseObject.pinAllInBackground(objects))
+        return TaskObservable.defer(() -> ParseObject.pinAllInBackground(objects).continueWith(v -> objects))
                 .flatMap(v -> Observable.fromIterable(objects));
     }
 


### PR DESCRIPTION
ParseObject.pinAllInBackground returns null resulted Task, this cause TaskObservable to complete without emission of any items. This makes the next map or flatMap inoperative and breaks the reactive chain
This PR fixes the problem.